### PR TITLE
fix:bug where latest park info wasn't retrieved after image edit modi…

### DIFF
--- a/src/components/organisms/EditForm.tsx
+++ b/src/components/organisms/EditForm.tsx
@@ -87,6 +87,7 @@ export const EditForm = memo((props: Props) => {
         },
       })
         .then(() => {
+          handleGetParks();
           handleGetImages(undefined);
           setMessage({ message: "更新しました", type: "success" });
         })
@@ -116,8 +117,6 @@ export const EditForm = memo((props: Props) => {
     setPrefectureName("");
     setCityName("");
     setTakenDate(null);
-
-    handleGetParks();
     setSelectedIds([]);
     setSelectedIndexes([]);
   };


### PR DESCRIPTION
画像編集ページで撮影場所を新規で追加して保存ボタンを押しても撮影場所が更新されないバグを修正しました。