### PR TITLE
fix:compiler add in next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,4 +2,7 @@ module.exports = {
   images: {
     domains: ["localhost"],
   },
+  compiler: {
+    styledComponents: true,
+  },
 };


### PR DESCRIPTION
NextjsのProp className did not matchのエラー修正をしました。