### PR TITLE
fix:park name reset to empty string in EditForm

### DIFF
--- a/src/app/_components/imageedit/EditForm.tsx
+++ b/src/app/_components/imageedit/EditForm.tsx
@@ -121,6 +121,7 @@ export const EditForm = memo((props: Props) => {
     setInsectName("");
     setValue("");
     setInputValue("");
+    setParkName("");
     setPrefectureName("");
     setCityName("");
     setTakenDate(null);


### PR DESCRIPTION
EditFormで画像データの保存、削除をした後に、ParkNameを空にするように修正