### PR TITLE
fix:platform designated to github actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       ## Build Docker Image Build
       - name: Build an Image
         run: |
-          docker build -t fable-production-frontend .
+          docker build --platform linux/arm64 -t fable-production-frontend .
       ## Login AWS
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
github actions workflowファイルのbuildコマンドのところにplatform linux/arm64を指定しました。