### PR TITLE
fix:search result bun from top page modified

### DIFF
--- a/src/app/_components/map/InsectSearchBox.tsx
+++ b/src/app/_components/map/InsectSearchBox.tsx
@@ -28,7 +28,6 @@ type Props = {
   insectOptions: string[];
   queryWord: string;
   setQueryWord: (queryWord: string) => void;
-  setSearchInitiated: (searchInitiated: boolean) => void;
 };
 
 export const InsectSearchBox = memo((props: Props) => {
@@ -39,7 +38,6 @@ export const InsectSearchBox = memo((props: Props) => {
     handleGetParkSearchResults,
     insectOptions,
     setQueryWord,
-    setSearchInitiated,
   } = props;
 
   const searchWord = useRecoilValue(searchWordState);
@@ -47,7 +45,6 @@ export const InsectSearchBox = memo((props: Props) => {
 
   const handleSearch = () => {
     setOpen(true);
-    setSearchInitiated(true);
     handleGetParkSearchResults(searchWord);
   };
 

--- a/src/app/_components/map/MapDrawer.tsx
+++ b/src/app/_components/map/MapDrawer.tsx
@@ -58,7 +58,6 @@ export const MapDrawer = memo((props: Props) => {
   const [selectedItemId, setSelectedItemId] = useRecoilState(selectedItemState);
   const searchWord = useRecoilValue(searchWordState);
   const [open, setOpen] = useState(true);
-  const [searchInitiated, setSearchInitiated] = useState(false);
 
   const handleListItem = (result: Park) => {
     setSelectedItemId(result.id);
@@ -77,10 +76,6 @@ export const MapDrawer = memo((props: Props) => {
       topListItemRef.current.scrollIntoView({ behavior: "smooth" });
     }
   }, [selectedItemId]);
-
-  useEffect(() => {
-    setSearchInitiated(false);
-  }, [searchWord]);
 
   return (
     <Box sx={{ display: "flex" }}>
@@ -102,7 +97,6 @@ export const MapDrawer = memo((props: Props) => {
           insectOptions={insectOptions}
           queryWord={queryWord}
           setQueryWord={setQueryWord}
-          setSearchInitiated={setSearchInitiated}
         />
       </SearchBoxStyled>
       <Drawer
@@ -133,7 +127,7 @@ export const MapDrawer = memo((props: Props) => {
               >
                 <CircularProgress />
               </Box>
-            ) : searchInitiated && searchWord && searchResults.length === 0 ? (
+            ) : searchWord && searchResults.length === 0 ? (
               <ListItem>
                 <SListItemText primary="検索した昆虫は見つかりません。" />
               </ListItem>


### PR DESCRIPTION
Topページから検索して該当データが無かった場合のMapページでの検索結果の挙動を修正