### PR TITLE
fix:disappearing origin&destination&route results on-reload modified

### DIFF
--- a/src/app/_components/direction/Direction.tsx
+++ b/src/app/_components/direction/Direction.tsx
@@ -9,7 +9,9 @@ import {
   destinationLocationState,
   originLocationState,
   searchResultsState,
+  useOriginLocation,
 } from "../../../store/atoms/searchWordState";
+import { mapToDirectionState } from "../../../store/atoms/MapDirectionState";
 import { Box } from "@mui/material";
 import { Anchor, Steps, TravelMode } from "../../../types/map";
 import { usePageSize } from "../../../hooks/usePageSize";
@@ -19,7 +21,7 @@ export const Direction = () => {
   const searchResults = useRecoilValue(searchResultsState);
 
   const originLocation = useRecoilValue(originLocationState);
-  const saveOriginLocation = useSetRecoilState(originLocationState);
+  const { saveOriginLocation } = useOriginLocation();
   const [directions, setDirections] = useState<
     google.maps.DirectionsResult | undefined
   >(undefined);
@@ -29,6 +31,7 @@ export const Direction = () => {
   const [steps, setSteps] = useState<Steps[]>([]);
   const [anchor, setAnchor] = useState<Anchor>("left");
   const destinationLocation = useRecoilValue(destinationLocationState);
+  const setMapToDirection = useSetRecoilState(mapToDirectionState);
   const originRef = useRef<HTMLInputElement>(null);
   const destinationRef = useRef<HTMLInputElement>(null);
   const mapRef = useRef<google.maps.Map | null>(null);
@@ -62,6 +65,8 @@ export const Direction = () => {
     }
     setShouldCleanup(true);
     setDirections(undefined);
+    setMapToDirection(false);
+
     const directionsService = new window.google.maps.DirectionsService();
     directionsService
       .route(

--- a/src/app/_components/direction/DirectionDrawer.tsx
+++ b/src/app/_components/direction/DirectionDrawer.tsx
@@ -1,10 +1,14 @@
 "use client";
 
-import React, { memo, useRef, useState } from "react";
+import React, { memo, useEffect, useRef, useState } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { useRouter } from "next/navigation";
 import parser from "html-react-parser";
-import { selectedCenterState } from "../../../store/atoms/MapDirectionState";
+import {
+  mapApiLoadState,
+  mapToDirectionState,
+  selectedCenterState,
+} from "../../../store/atoms/MapDirectionState";
 import { Header } from "../headerfotter/Header";
 import { DestinationBox } from "./DestinationBox";
 import { OriginBox } from "./OriginBox";
@@ -86,6 +90,8 @@ export const DirectionDrawer = memo((props: Props) => {
   const router = useRouter();
   const originLocation = useRecoilValue(originLocationState);
   const destinationLocation = useRecoilValue(destinationLocationState);
+  const mapLoadState = useRecoilValue(mapApiLoadState);
+  const mapToDirection = useRecoilValue(mapToDirectionState);
   const [isRouteVisible, setIsRouteVisible] = useState<boolean>(false);
 
   // リストをスクロールする
@@ -98,6 +104,17 @@ export const DirectionDrawer = memo((props: Props) => {
       lng: step.latLng.lng,
     });
   };
+
+  useEffect(() => {
+    if (
+      !mapToDirection &&
+      mapLoadState.isLoaded &&
+      originLocation &&
+      destinationLocation
+    ) {
+      calculateRoute();
+    }
+  }, [mapLoadState.isLoaded]);
 
   return (
     <Box sx={{ display: "flex" }}>

--- a/src/app/_components/map/InsectSearchBox.tsx
+++ b/src/app/_components/map/InsectSearchBox.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import React, { memo } from "react";
-import { useRecoilValue } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import { useRouter } from "next/navigation";
 import {
   searchWordState,
   useDestinationLocation,
   useSearchWord,
 } from "../../../store/atoms/searchWordState";
+import {
+  mapToDirectionState,
+} from "../../../store/atoms/MapDirectionState";
 import { convertHiraganaToKatakana } from "../../../hooks/useConvertHiraganaToKatakana";
 import Divider from "@mui/material/Divider";
 import IconButton from "@mui/material/IconButton";
@@ -43,6 +46,7 @@ export const InsectSearchBox = memo((props: Props) => {
   } = props;
 
   const searchWord = useRecoilValue(searchWordState);
+  const setMapToDirection = useSetRecoilState(mapToDirectionState);
   const { saveSearchWord } = useSearchWord();
   const { saveDestinationLocation } = useDestinationLocation();
   const selectedItemName = useRecoilValue(selectedItemNameState);
@@ -60,6 +64,7 @@ export const InsectSearchBox = memo((props: Props) => {
   const router = useRouter();
   const handleDirectionButtonClick = () => {
     if (selectedItemName === undefined) return;
+    setMapToDirection(true);
     saveDestinationLocation(selectedItemName);
     router.push("/direction");
   };

--- a/src/store/atoms/MapDirectionState.ts
+++ b/src/store/atoms/MapDirectionState.ts
@@ -35,3 +35,8 @@ export const mapApiLoadState = atom<MapApiLoad>({
     loadError: false,
   },
 });
+
+export const mapToDirectionState = atom<boolean>({
+  key: "mapToDirectionState",
+  default: false,
+});

--- a/src/store/atoms/searchWordState.ts
+++ b/src/store/atoms/searchWordState.ts
@@ -9,6 +9,7 @@ type DestinationLocation = string;
 
 // searchWordをlocalStorageに保存し状態を管理する
 const initializeSearchWord = () => {
+  // build時に発生するエラーを回避するための処理
   if (typeof window === "undefined") {
     return "";
   }
@@ -37,9 +38,16 @@ export const useSearchWord = () => {
 };
 
 //OriginをlocalStorageに保存し状態を管理する
+const initializeOriginLocation = () => {
+  if (typeof window === "undefined") {
+    return "";
+  }
+  const savedOriginLocation = localStorage.getItem("originLocation");
+  return savedOriginLocation ? savedOriginLocation : "";
+};
 export const originLocationState = atom<OriginLocation>({
   key: "originLocationState",
-  default: "",
+  default: initializeOriginLocation(),
 });
 
 export const useOriginLocation = () => {
@@ -60,9 +68,16 @@ export const useOriginLocation = () => {
 };
 
 //DestinationをlocalStorageに保存し状態を管理する
+const initializeDestinationLocation = () => {
+  if (typeof window === "undefined") {
+    return "";
+  }
+  const savedDestinationLocation = localStorage.getItem("destinationLocation");
+  return savedDestinationLocation ? savedDestinationLocation : "";
+};
 export const destinationLocationState = atom<DestinationLocation>({
   key: "destinationLocationState",
-  default: "",
+  default: initializeDestinationLocation(),
 });
 export const useDestinationLocation = () => {
   const [destinationLocation, setDestinationLocation] = useRecoilState(


### PR DESCRIPTION
Dicretionページにおいて、ブラウザリロードした際に出発地、目的地、経路が消えるバグを修正