### PR TITLE
Fix map&postlist UI updated

### DIFF
--- a/src/app/_components/map/MapDrawer.tsx
+++ b/src/app/_components/map/MapDrawer.tsx
@@ -184,7 +184,6 @@ export const MapDrawer = memo((props: Props) => {
                 </React.Fragment>
               ))
             )}
-            <Divider />
           </List>
         </Box>
       </Drawer>

--- a/src/app/_components/postlist/PostList.tsx
+++ b/src/app/_components/postlist/PostList.tsx
@@ -245,6 +245,7 @@ export const PostList = () => {
                               {imageData.insectName && (
                                 <Box
                                   sx={{
+                                    paddingLeft: "5px",
                                     fontSize: {
                                       xs: "12px",
                                       md: "16px",
@@ -267,11 +268,13 @@ export const PostList = () => {
                               <Box
                                 sx={{
                                   display: "flex",
+                                  flexDirection: "column",
                                   justifyContent: "flex-start",
                                 }}
                               >
                                 <Box
                                   sx={{
+                                    paddingLeft: "5px",
                                     fontSize: {
                                       xs: "12px",
                                       md: "16px",


### PR DESCRIPTION
MapDrawerのlistの一番下のDividerを削除しました。
postlistのcard下部の昆虫名、場所、撮影日時の左側にpaddingを追加しました。