### PR TITLE
Feat links and responsive desigin add in picturebook, header

### DIFF
--- a/src/app/_components/headerfotter/Header.tsx
+++ b/src/app/_components/headerfotter/Header.tsx
@@ -164,6 +164,12 @@ export const Header = () => {
                       <MenuItem onClick={handleClose}>
                         <SLink href="/statistics">分析</SLink>
                       </MenuItem>
+                      <MenuItem onClick={handleClose}>
+                        <SLink href="/picturebooklist">図鑑</SLink>
+                      </MenuItem>
+                      <MenuItem onClick={handleClose}>
+                        <SLink href="/usernotificationlist">通知</SLink>
+                      </MenuItem>
                     </Box>
                   )}
                   {loginUser === undefined ? (

--- a/src/app/_components/picturebook/ActiveHourChart.tsx
+++ b/src/app/_components/picturebook/ActiveHourChart.tsx
@@ -13,10 +13,11 @@ import { Box, Paper, useTheme } from "@mui/material";
 ChartJS.register(LinearScale, BarElement, CategoryScale);
 type Props = {
   pictureBookInfo?: PictureBookInfo;
+  pageSize: number;
 };
 
 export const ActiveHourChart = (props: Props) => {
-  const { pictureBookInfo } = props;
+  const { pictureBookInfo, pageSize } = props;
   const theme = useTheme();
 
   const dataHours = {
@@ -45,6 +46,7 @@ export const ActiveHourChart = (props: Props) => {
   const options = {
     indexAxis: "y" as const,
     responsive: true,
+    maintainAspectRatio: false,
     scales: {
       x: {
         title: {
@@ -63,7 +65,7 @@ export const ActiveHourChart = (props: Props) => {
         elevation={0}
       >
         <Box sx={{ padding: theme.spacing(2) }}>
-          <Box>
+          <Box sx={{ height: pageSize > 8 ? "400px" : "300px" }}>
             <Bar data={dataHours} options={options} />
           </Box>
         </Box>

--- a/src/app/_components/picturebook/ActiveMonthChart.tsx
+++ b/src/app/_components/picturebook/ActiveMonthChart.tsx
@@ -13,9 +13,10 @@ import { Box, Paper, useTheme } from "@mui/material";
 ChartJS.register(LinearScale, BarElement, CategoryScale);
 type Props = {
   pictureBookInfo?: PictureBookInfo;
+  pageSize: number;
 };
 export const ActiveMonthChart = (props: Props) => {
-  const { pictureBookInfo } = props;
+  const { pictureBookInfo, pageSize } = props;
   const theme = useTheme();
 
   const dataMonths = {
@@ -48,6 +49,7 @@ export const ActiveMonthChart = (props: Props) => {
   const options = {
     indexAxis: "y" as const,
     responsive: true,
+    maintainAspectRatio: false,
     scales: {
       x: {
         title: {
@@ -66,7 +68,7 @@ export const ActiveMonthChart = (props: Props) => {
         elevation={0}
       >
         <Box sx={{ padding: theme.spacing(2) }}>
-          <Box>
+          <Box sx={{ height: pageSize > 8 ? "500px" : "300px" }}>
             <Bar data={dataMonths} options={options} />
           </Box>
         </Box>

--- a/src/app/_components/picturebook/PictureBook.tsx
+++ b/src/app/_components/picturebook/PictureBook.tsx
@@ -7,6 +7,7 @@ import styled from "styled-components";
 import { sightingNotificationState } from "../../../store/atoms/notificationAtom";
 import { useSearchWord } from "../../../store/atoms/searchWordState";
 import { createHandleNotificationSetting } from "../../_utils/sightingnotificationUtils";
+import { usePageSize } from "../../../hooks/usePageSize";
 import { ActiveMonthChart } from "./ActiveMonthChart";
 import { ActiveHourChart } from "./ActiveHourChart";
 import { usePictureBook } from "../../../hooks/usePictureBooks";
@@ -40,6 +41,7 @@ export const PictureBook = (props: Props) => {
     isNotificationLoading,
   } = useInsectSightingNotifications(insectId);
   const { saveSearchWord } = useSearchWord();
+  const pageSize = usePageSize();
 
   // 画像の順序をいいね順に並び替える
   const sortedImages = pictureBookInfo?.collectedInsectImages
@@ -249,6 +251,7 @@ export const PictureBook = (props: Props) => {
             </Typography>
             <ActiveMonthChart
               pictureBookInfo={pictureBookInfo && pictureBookInfo}
+              pageSize={pageSize}
             />
             {/* 活動時間 */}
             <Typography variant="h6" gutterBottom>
@@ -256,6 +259,7 @@ export const PictureBook = (props: Props) => {
             </Typography>
             <ActiveHourChart
               pictureBookInfo={pictureBookInfo && pictureBookInfo}
+              pageSize={pageSize}
             />
             <Typography variant="h6" gutterBottom>
               最近の出没先

--- a/src/app/_components/picturebook/PictureBook.tsx
+++ b/src/app/_components/picturebook/PictureBook.tsx
@@ -109,7 +109,7 @@ export const PictureBook = (props: Props) => {
                 variant="outlined"
                 sx={{ p: 0, backgroundColor: "#F2F2F2", borderRadius: "10px" }}
               >
-                <Grid container spacing={0.5}>
+                <Grid container>
                   {/* 左半分 */}
                   <Grid item xs={12} sm={6}>
                     <Box
@@ -125,7 +125,7 @@ export const PictureBook = (props: Props) => {
                   </Grid>
                   {/* 右半分 */}
                   <Grid item xs={12} sm={6}>
-                    <Grid container spacing={0.5}>
+                    <Grid container>
                       {sortedImages?.slice(1, 5).map((image, index) => (
                         <Grid item xs={6} key={index}>
                           <Box
@@ -148,7 +148,7 @@ export const PictureBook = (props: Props) => {
           ) : (
             <Box sx={{ my: 2 }}>
               <Paper variant="outlined" sx={{ p: 0 }}>
-                <Grid container spacing={0.5}>
+                <Grid container>
                   {/* 左半分 */}
                   <Grid item xs={12} sm={6}>
                     <Skeleton
@@ -160,7 +160,7 @@ export const PictureBook = (props: Props) => {
                   </Grid>
                   {/* 右半分 */}
                   <Grid item xs={12} sm={6}>
-                    <Grid container spacing={0.5}>
+                    <Grid container>
                       {[...Array(4)].map((_, index) => (
                         <Grid item xs={6} key={index}>
                           <Skeleton

--- a/src/app/_components/statistics/CollectionStatusTable.tsx
+++ b/src/app/_components/statistics/CollectionStatusTable.tsx
@@ -220,7 +220,13 @@ export const CollectionStatusTable = (props: Props) => {
                         fontSize: pageSize > 8 ? "16px" : "12px",
                       }}
                     >
-                      <Typography variant="body1" color="text.primary">
+                      <Typography
+                        variant="body1"
+                        color="text.primary"
+                        sx={{
+                          fontSize: pageSize > 8 ? "16px" : "12px",
+                        }}
+                      >
                         {row.insectName}
                       </Typography>
                       <SLink


### PR DESCRIPTION
以下3点を変更しました：

1. HeaderのMenuItemに「図鑑」と「通知」ページへのリンクを追加しました。

2. 以下の要素にレスポンシブデザインを適用しました：
StatisticsページのCollectionStatusTableの昆虫名
PictureBookページのActiveMonthChart
PictureBookページのActiveHourChart

3. PictureBookページの画像表示欄において、画像間のスペースを削除しました。