### PR TITLE
fix:search bar bug in filtering functionality on picture book list page modified

### DIFF
--- a/src/app/_components/picturebooklist/SearchBarInPictureBookList.tsx
+++ b/src/app/_components/picturebooklist/SearchBarInPictureBookList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { convertHiraganaToKatakana } from "../../../hooks/useConvertHiraganaToKatakana";
 import { TextField } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
@@ -9,12 +9,16 @@ import { styled as muiStyled, alpha } from "@mui/material/styles";
 type Props = {
   searchTerm: string;
   setSearchTerm: (searchTerm: string) => void;
-  handleSearch: (e: React.KeyboardEvent) => void;
+  handleSearch: () => void;
 };
 
 export const SearchBarInPictureBookList = (props: Props) => {
-  const { setSearchTerm, handleSearch } = props;
+  const { searchTerm, setSearchTerm, handleSearch } = props;
   const [searchWord, setSearchWord] = useState<string>("");
+
+  useEffect(() => {
+    handleSearch();
+  }, [searchTerm]);
 
   return (
     <>
@@ -30,7 +34,6 @@ export const SearchBarInPictureBookList = (props: Props) => {
           if (e.key === "Enter") {
             const convertedInputValue = convertHiraganaToKatakana(searchWord);
             setSearchTerm(convertedInputValue);
-            handleSearch(e);
           }
         }}
         InputProps={{


### PR DESCRIPTION
図鑑リストページの検索欄で名前を入力してEnterを押すと、検索結果が正しく反映される前に検索処理が実行されてしまい、フィルタリング結果が期待通りに表示されないバグを修正しました。